### PR TITLE
eliminate unnecessary code and reduce confusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /docs/_build
 /vendor/
 composer.lock
+./.idea

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -290,7 +290,7 @@ class Connection extends Component
         }
 
         if ($this->_cache) {
-            $cache =  Yii::createObject($this->_cache ?: $this->cacheComponent);
+            $cache =  Yii::createObject($this->_cache);
             if (!$cache instanceof CacheInterface) {
                 throw new InvalidConfigException('Cache component must be implements yii\caching\CacheInterface');
             }


### PR DESCRIPTION
**only $this-_cache is true this code will execute ,so $this-cacheComponent will not be used**

```
       if ($this->_cache) {
 
            $cache =  Yii::createObject($this->_cache ?: $this->cacheComponent);
            ......
        } else {
            ......
        }
```
